### PR TITLE
Add root helper scripts for running dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,31 @@ Real-time speech recognition web app powered by [faster-whisper](https://github.
 
 ## Quick Start
 
-1. **Start the ASR server**
-   ```bash
-   cd app/server
-   bash run.sh
-   ```
-   This creates a virtualenv, installs dependencies and launches the WebSocket server on `ws://127.0.0.1:8765`.
+1. **Run both client and server together**
 
-2. **Serve the client**
-   - Option A: open `app/client/index.html` in a browser directly.
-   - Option B: use the lightweight static host:
+   ```bash
+   npm run dev
+   ```
+
+   This starts the WebSocket ASR server and serves the client concurrently using helper scripts in `app/`.
+
+2. **Or start each component manually**
+
+   - **Start the ASR server**
      ```bash
-     cd app
-     npx serve
+     cd app/server
+     bash run.sh
      ```
-     or run `npm run serve` if you installed dependencies.
+     This creates a virtualenv, installs dependencies and launches the WebSocket server on `ws://127.0.0.1:8765`.
+
+   - **Serve the client**
+     - Option A: open `app/client/index.html` in a browser directly.
+     - Option B: use the lightweight static host:
+       ```bash
+       cd app
+       npx serve
+       ```
+       or run `npm run serve` if you installed dependencies.
 
 3. Open the page in your browser, grant microphone permission, choose a language and press **Start**.
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "whisper-live-transcriber-root",
+  "private": true,
+  "scripts": {
+    "serve": "npm --prefix app run serve",
+    "asr": "npm --prefix app run asr",
+    "dev": "npm --prefix app run dev"
+  }
+}


### PR DESCRIPTION
## Summary
- add a root-level `package.json` with `serve`, `asr`, and `dev` helper scripts that proxy into `app/`
- document the new `npm run dev` command in the Quick Start guide

## Testing
- `npm run dev` (starts client and ASR server)
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_689f5df04bf88320a3c370269adeac1a