### PR TITLE
Fix dev server file path resolution

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "serve": "node -e \"require('http').createServer((req,res)=>require('fs').createReadStream(require('path').join('client', req.url==='/'?'/index.html':req.url)).on('error',()=>res.end('404')).pipe(res)).listen(8080); console.log('http://127.0.0.1:8080')\"",
+    "serve": "node -e \"require('http').createServer((req,res)=>require('fs').createReadStream(require('path').join('client', req.url==='/'?'index.html':req.url.slice(1))).on('error',()=>res.end('404')).pipe(res)).listen(8080); console.log('http://127.0.0.1:8080')\"",
     "asr": "bash server/run.sh",
     "dev": "concurrently \"npm:serve\" \"npm:asr\""
   },


### PR DESCRIPTION
## Summary
- ensure dev server serves files from client directory by handling leading slashes correctly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fd1871428832088110c4edb1b4b5e