### PR TITLE
feat: add cross-platform server runner with basic logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,19 @@ Real-time speech recognition web app powered by [faster-whisper](https://github.
 2. **Or start each component manually**
 
    - **Start the ASR server**
+
      ```bash
+     # macOS / Linux
      cd app/server
-     bash run.sh
+     python3 run.py
+     
+     # Windows (PowerShell)
+     cd app\server
+     python run.py
      ```
-     This creates a virtualenv, installs dependencies and launches the WebSocket server on `ws://127.0.0.1:8765`.
+
+     `run.py` creates a virtualenv, installs dependencies and launches the WebSocket server on `ws://127.0.0.1:8765`.
+     Set `ENABLE_HEALTH_ENDPOINT=1` to also expose `http://127.0.0.1:8766/health`.
 
    - **Serve the client**
      - Option A: open `app/client/index.html` in a browser directly.
@@ -30,16 +38,30 @@ Real-time speech recognition web app powered by [faster-whisper](https://github.
        ```
        or run `npm run serve` if you installed dependencies.
 
-3. Open the page in your browser, grant microphone permission, choose a language and press **Start**.
+3. **Run tests**
+
+   ```bash
+   cd app
+   pytest server/tests
+   ```
+
+4. Open the page in your browser, grant microphone permission, choose a language and press **Start**.
 
 ## Repository Layout
 
 ```
 app/
   client/      # Browser front-end
-  server/      # Python WebSocket ASR server
+  server/      # Python WebSocket ASR server with minimal logging
 package.json   # Optional helper scripts
 ```
+
+## Architecture
+
+Audio is captured in the browser, converted to 16 kHz mono PCM and streamed over WebSocket
+to the Python server. The server transcribes short audio windows using faster‑whisper and
+returns partial and final transcripts. Optional health information is served on an HTTP
+endpoint when enabled.
 
 ## Notes
 

--- a/app/client/app.js
+++ b/app/client/app.js
@@ -33,6 +33,19 @@ function render() {
   }
 }
 
+window.addEventListener("error", (e) => {
+  try {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(
+        JSON.stringify({
+          type: "client-error",
+          message: String(e.message || "").slice(0, 200),
+        })
+      );
+    }
+  } catch {}
+});
+
 function floatTo16BitPCM(float32Array) {
   const buf = new Int16Array(float32Array.length);
   for (let i = 0; i < float32Array.length; i++) {

--- a/app/server/asr_server.py
+++ b/app/server/asr_server.py
@@ -1,14 +1,82 @@
-import asyncio, json, time
+import asyncio
+import json
+import os
+import socket
+import threading
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
 import numpy as np
 from websockets.server import serve
-from faster_whisper import WhisperModel
+
+try:  # Optional for lightweight testing environments
+    from faster_whisper import WhisperModel  # type: ignore
+except Exception:  # pragma: no cover - handled in __init__
+    WhisperModel = None  # type: ignore
 
 SR = 16000
 
+
+def check_environment(host: str, port: int, log_dir: str) -> None:
+    """Validate basic runtime assumptions before starting the server."""
+    os.makedirs(log_dir, exist_ok=True)
+    if not os.access(log_dir, os.W_OK):
+        raise RuntimeError(f"Log directory {log_dir!r} is not writable")
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        if s.connect_ex((host, port)) == 0:
+            raise RuntimeError(f"Port {port} already in use on {host}")
+
+
+class Logger:
+    """Minimal structured logger with request IDs."""
+
+    def __init__(self) -> None:
+        self.level = os.getenv("LOG_LEVEL", "INFO").upper()
+
+    def _log(
+        self, level: str, msg: str, request_id: str | None = None
+    ) -> None:
+        if level not in {"INFO", "WARN", "ERROR"}:
+            return
+        if level == "INFO" and self.level not in {"INFO"}:
+            return
+        if level == "WARN" and self.level not in {"INFO", "WARN"}:
+            return
+        rid = request_id or "-"
+        print(
+            f"{time.strftime('%Y-%m-%dT%H:%M:%S')} {level} [{rid}] {msg}"
+        )
+
+    def info(self, msg: str, request_id: str | None = None) -> None:
+        self._log("INFO", msg, request_id)
+
+    def warn(self, msg: str, request_id: str | None = None) -> None:
+        self._log("WARN", msg, request_id)
+
+    def error(self, msg: str, request_id: str | None = None) -> None:
+        self._log("ERROR", msg, request_id)
+
+
+log = Logger()
+
+
 class ASRServer:
-    def __init__(self, model_size="medium", compute_type="int8_float16"):
-        self.model = WhisperModel(model_size, compute_type=compute_type)
-        self.lang = None
+    def __init__(
+        self,
+        model_size: str | None = None,
+        compute_type: str | None = None,
+        model: object | None = None,
+    ) -> None:
+        if model is not None:
+            self.model = model
+        else:
+            if WhisperModel is None:
+                raise RuntimeError("faster-whisper is not installed")
+            ms = model_size or os.getenv("ASR_MODEL_SIZE", "medium")
+            ct = compute_type or os.getenv("ASR_COMPUTE_TYPE", "int8_float16")
+            self.model = WhisperModel(ms, compute_type=ct)
+        self.lang: str | None = None
         self.buf = np.zeros(0, dtype=np.float32)
         self.last_emit = 0.0
         self.last_partial = ""
@@ -34,14 +102,49 @@ class ASRServer:
             audio,
             language=self.lang,
             vad_filter=True,
-            beam_size=1
+            beam_size=1,
         )
         text = "".join(s.text for s in segs).strip()
         return text
 
-asr = ASRServer()
+
+HOST = os.getenv("ASR_HOST", "127.0.0.1")
+PORT = int(os.getenv("ASR_PORT", "8765"))
+LOG_DIR = os.getenv("ASR_LOG_DIR", "logs")
+
+
+def start_health_server(host: str, port: int) -> None:
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # pragma: no cover - trivial
+            if self.path != "/health":
+                self.send_response(404)
+                self.end_headers()
+                return
+            body = json.dumps({"status": "ok"}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, fmt: str, *args: object) -> None:
+            pass  # pragma: no cover
+
+    server = HTTPServer((host, port), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+
+if os.getenv("ASR_SKIP_MODEL_LOAD") == "1":
+    _dummy = type("M", (), {"transcribe": lambda self, audio, **k: ([], None)})()
+    asr = ASRServer(model=_dummy)
+else:
+    asr = ASRServer()
+
 
 async def handler(ws):
+    req_id = uuid.uuid4().hex[:8]
+    log.info("client connected", req_id)
     await ws.send(json.dumps({"type": "info", "message": "asr-ready"}))
     try:
         async for msg in ws:
@@ -53,11 +156,18 @@ async def handler(ws):
                     if window is not None:
                         text = asr.transcribe_window(window)
                         if text and text != asr.last_partial:
-                            await ws.send(json.dumps({"type": "partial", "text": text}))
+                            await ws.send(
+                                json.dumps({"type": "partial", "text": text})
+                            )
                             asr.last_partial = text
                             asr.last_partial_time = now
-                        elif text == asr.last_partial and now - asr.last_partial_time > 1.0:
-                            await ws.send(json.dumps({"type": "final", "text": text}))
+                        elif (
+                            text == asr.last_partial
+                            and now - asr.last_partial_time > 1.0
+                        ):
+                            await ws.send(
+                                json.dumps({"type": "final", "text": text})
+                            )
                             asr.last_partial = ""
                         asr.last_emit = now
             else:
@@ -65,18 +175,35 @@ async def handler(ws):
                     obj = json.loads(msg)
                     if obj.get("type") == "control" and "setLanguage" in obj:
                         asr.set_language(obj["setLanguage"])
-                        await ws.send(json.dumps({"type": "info", "message": f"lang-set:{asr.lang or 'auto'}"}))
+                        await ws.send(
+                            json.dumps(
+                                {
+                                    "type": "info",
+                                    "message": f"lang-set:{asr.lang or 'auto'}",  # noqa: E501
+                                }
+                            )
+                        )
+                    elif obj.get("type") == "client-error":
+                        log.warn(f"client-error: {obj.get('message', '')}", req_id)  # noqa: E501
                 except Exception as e:
-                    await ws.send(json.dumps({"type": "error", "message": str(e)}))
-    except Exception as e:
+                    log.error(f"bad msg: {e}", req_id)
+                    await ws.send(json.dumps({"type": "error", "message": str(e)}))  # noqa: E501
+    except Exception as e:  # pragma: no cover - network errors
+        log.error(f"ws:{e}", req_id)
         try:
             await ws.send(json.dumps({"type": "error", "message": f"ws:{e}"}))
-        except:
+        except Exception:
             pass
 
-async def main():
-    async with serve(handler, "127.0.0.1", 8765, max_size=2**23):
+
+async def main() -> None:
+    check_environment(HOST, PORT, LOG_DIR)
+    if os.getenv("ENABLE_HEALTH_ENDPOINT") == "1":
+        start_health_server(HOST, PORT + 1)
+    async with serve(handler, HOST, PORT, max_size=2**23):
+        log.info(f"server listening on ws://{HOST}:{PORT}")
         await asyncio.Future()
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/app/server/run.py
+++ b/app/server/run.py
@@ -1,0 +1,26 @@
+import os
+import pathlib
+import subprocess
+import venv
+
+ROOT = pathlib.Path(__file__).resolve().parent
+VENV_DIR = ROOT / ".venv"
+PYTHON = VENV_DIR / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def ensure_venv() -> None:
+    if not VENV_DIR.exists():
+        venv.EnvBuilder(with_pip=True).create(VENV_DIR)
+    subprocess.check_call(
+        [str(PYTHON), "-m", "pip", "install", "-r", "requirements.txt"]
+    )
+
+
+def main() -> None:
+    ensure_venv()
+    env = os.environ.copy()
+    subprocess.check_call([str(PYTHON), "asr_server.py"], env=env)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/server/tests/test_window.py
+++ b/app/server/tests/test_window.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pathlib
+import sys
+import os
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+os.environ["ASR_SKIP_MODEL_LOAD"] = "1"
+from server import asr_server
+
+
+def test_pop_window():
+    dummy_model = type(
+        "M", (), {"transcribe": lambda self, audio, **k: ([], None)}
+    )()
+    s = asr_server.ASRServer(model=dummy_model)
+    s.append_pcm16((np.ones(asr_server.SR * 2, dtype=np.int16)).tobytes())
+    win = s.pop_window(seconds=1.0, keep=0.5)
+    assert win is not None
+    assert len(win) == asr_server.SR
+    assert len(s.buf) == int(asr_server.SR * 0.5)


### PR DESCRIPTION
## Summary
- add minimal logging utilities and environment checks to ASR server
- provide cross-platform `run.py` helper and health endpoint flag
- wire client error reporting and unit test for audio window logic

## Testing
- `python -m flake8 server/asr_server.py server/run.py server/tests/test_window.py`
- `pytest server/tests/test_window.py -q`
- `npm --prefix app run serve`


------
https://chatgpt.com/codex/tasks/task_e_68a007d213f48320b5b60a90e18ba262